### PR TITLE
Fixed negative max dimension bug

### DIFF
--- a/src/com/egorand/scrollableimageview/ScrollableImageView.java
+++ b/src/com/egorand/scrollableimageview/ScrollableImageView.java
@@ -65,11 +65,11 @@ public class ScrollableImageView extends ImageView {
 	}
 
 	private int getMaxHorizontal() {
-		return (getDrawable().getBounds().width() - screenW);
+		return (Math.abs(getDrawable().getBounds().width() - screenW));
 	}
 
 	private int getMaxVertical() {
-		return (getDrawable().getBounds().height() - screenH);
+		return (Math.abs(getDrawable().getBounds().height() - screenH));
 	}
 
 	private SimpleOnGestureListener gestureListener = new SimpleOnGestureListener() {


### PR DESCRIPTION
When the dimensions of the image are bigger than the device's screen resolution, the getMaxHorizontal/Vertical methods return a negative value which breaks the overscroller.

I fixed it by making getMaxHorizontal() and getMaxVertical() return the absolute value of the difference.
